### PR TITLE
Implement basic MDB example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # WildFly-MDB-SQL-Server
-POC
+
+Este proyecto contiene un ejemplo sencillo de un **Message-Driven Bean (MDB)** que escucha una cola JMS en WildFly y almacena los mensajes recibidos en una tabla de SQL Server.
+
+## Compilación
+
+```bash
+mvn clean package
+```
+
+El resultado es un archivo `wildfly-mdb-sqlserver-1.0-SNAPSHOT.jar` que puede desplegarse en WildFly.
+
+## Configuración en WildFly
+
+1. **Datasource a SQL Server**. Puede agregarse mediante el script `config/sqlserver-datasource.cli`:
+
+```bash
+# Dentro del directorio bin de WildFly
+./jboss-cli.sh --file=../config/sqlserver-datasource.cli
+```
+
+2. **Cola JMS**. Se declara con el script `config/jms-queue.cli`:
+
+```bash
+./jboss-cli.sh --file=../config/jms-queue.cli
+```
+
+3. Cree la tabla de ejemplo ejecutando `sql/create-table.sql` en la base de datos.
+
+## Descripción del MDB
+
+El bean `MessageProcessorBean` se encuentra en `src/main/java`. Está anotado con `@MessageDriven` para escuchar la cola `java:/jms/queue/ExampleQueue` y utiliza el datasource `java:jboss/datasources/SQLServerDS` para persistir cada mensaje en la tabla `messages`.
+
+## Despliegue
+
+Copie el JAR generado al directorio `standalone/deployments` de WildFly.
+

--- a/config/jms-queue.cli
+++ b/config/jms-queue.cli
@@ -1,0 +1,1 @@
+jms-queue add --queue-address=ExampleQueue --entries=java:/jms/queue/ExampleQueue

--- a/config/sqlserver-datasource.cli
+++ b/config/sqlserver-datasource.cli
@@ -1,0 +1,5 @@
+module add --name=com.microsoft.sqlserver --resources=path/to/sqljdbc.jar --dependencies=javax.api,javax.transaction.api
+
+/subsystem=datasources/jdbc-driver=sqlserver:add(driver-name=sqlserver,driver-module-name=com.microsoft.sqlserver,driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver)
+
+/subsystem=datasources/data-source=SQLServerDS:add(jndi-name=java:jboss/datasources/SQLServerDS, driver-name=sqlserver, connection-url=jdbc:sqlserver://localhost:1433;databaseName=mydb, user-name=sa, password=sa_passwd)

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>wildfly-mdb-sqlserver</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>ejb</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <version>9.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.10.1</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/sql/create-table.sql
+++ b/sql/create-table.sql
@@ -1,0 +1,4 @@
+CREATE TABLE messages (
+    id INT IDENTITY PRIMARY KEY,
+    content NVARCHAR(255)
+);

--- a/src/main/java/com/example/mdb/MessageProcessorBean.java
+++ b/src/main/java/com/example/mdb/MessageProcessorBean.java
@@ -1,0 +1,39 @@
+package com.example.mdb;
+
+import jakarta.annotation.Resource;
+import jakarta.ejb.ActivationConfigProperty;
+import jakarta.ejb.MessageDriven;
+import jakarta.jms.Message;
+import jakarta.jms.MessageListener;
+import jakarta.jms.TextMessage;
+import jakarta.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+@MessageDriven(activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "jakarta.jms.Queue"),
+        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = "java:/jms/queue/ExampleQueue")
+})
+public class MessageProcessorBean implements MessageListener {
+
+    @Resource(lookup = "java:jboss/datasources/SQLServerDS")
+    private DataSource dataSource;
+
+    @Override
+    public void onMessage(Message message) {
+        try (Connection connection = dataSource.getConnection()) {
+            String text;
+            if (message instanceof TextMessage) {
+                text = ((TextMessage) message).getText();
+            } else {
+                text = message.getBody(String.class);
+            }
+            PreparedStatement ps = connection.prepareStatement("INSERT INTO messages(content) VALUES (?)");
+            ps.setString(1, text);
+            ps.executeUpdate();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/example/mdb/MessageProcessorBean.java
+++ b/src/main/java/com/example/mdb/MessageProcessorBean.java
@@ -29,9 +29,10 @@ public class MessageProcessorBean implements MessageListener {
             } else {
                 text = message.getBody(String.class);
             }
-            PreparedStatement ps = connection.prepareStatement("INSERT INTO messages(content) VALUES (?)");
-            ps.setString(1, text);
-            ps.executeUpdate();
+            try (PreparedStatement ps = connection.prepareStatement("INSERT INTO messages(content) VALUES (?)")) {
+                ps.setString(1, text);
+                ps.executeUpdate();
+            }
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
## Summary
- add a Maven EJB project that persists JMS messages to SQL Server
- include WildFly CLI scripts to configure JMS queue and datasource
- document the build and deployment process in Spanish

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68419dc85f188329b8bbbfffa0d15428