### PR TITLE
Explain how to specify JDBC driver path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ El resultado es un archivo `wildfly-mdb-sqlserver-1.0-SNAPSHOT.jar` que puede de
 
 ## Configuración en WildFly
 
-1. **Datasource a SQL Server**. Puede agregarse mediante el script `config/sqlserver-datasource.cli`.  Este archivo contiene la instrucción `module add` con una ruta al driver JDBC de SQL Server (`path/to/sqljdbc.jar`). Descargue el driver desde [Microsoft](https://learn.microsoft.com/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server) y edite la ruta en el script antes de ejecutarlo:
+1. **Datasource a SQL Server**. Puede agregarse mediante el script `config/sqlserver-datasource.cli`.  Este archivo contiene la instrucción `module add` con una ruta al driver JDBC de SQL Server (`path/to/sqljdbc.jar`). Descargue el driver desde [Microsoft](https://learn.microsoft.com/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server) y reemplace `path/to/sqljdbc.jar` con la ubicación real del archivo (por ejemplo `/opt/sqljdbc/sqljdbc42.jar`) antes de ejecutar el script:
 
 ```bash
 # Dentro del directorio bin de WildFly

--- a/config/sqlserver-datasource.cli
+++ b/config/sqlserver-datasource.cli
@@ -1,3 +1,6 @@
+# Replace 'path/to/sqljdbc.jar' with the location of the JDBC driver JAR.
+# The driver can be downloaded from:
+# https://learn.microsoft.com/sql/connect/jdbc/download-microsoft-jdbc-driver-for-sql-server
 module add --name=com.microsoft.sqlserver --resources=path/to/sqljdbc.jar --dependencies=javax.api,javax.transaction.api
 
 /subsystem=datasources/jdbc-driver=sqlserver:add(driver-name=sqlserver,driver-module-name=com.microsoft.sqlserver,driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver)


### PR DESCRIPTION
## Summary
- point to Microsoft's download URL in sqlserver-datasource CLI
- explain in README how to replace the placeholder path with the real JDBC driver location

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a90e3a488329978e4c513e3e1a70